### PR TITLE
Added the standard composer autoloader in the sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Using it is rather simple:
 
 ```php
 <?php
+require_once("vendor/autoload.php");
 use IslamicNetwork\PrayerTimes\PrayerTimes;
 
 // Instantiate the class with your chosen method, Juristic School for Asr and if you want or own Asr factor, make the juristic school null and pass your own Asr shadow factor as the third parameter. Note that all parameters are optional.


### PR DESCRIPTION
Otherwise a `Fatal error: Uncaught Error: Class 'IslamicNetwork\PrayerTimes\PrayerTimes' not found in D:\www\poc\prayer\index.php on line 6` would occur